### PR TITLE
Add Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+os: linux
+arch:
+ - s390x
+ - amd64
+ - ppc64le
+dist: bionic
+
+services:
+  - docker
+
+install:
+  - docker pull ubuntu:eoan
+  - echo FROM ubuntu:eoan > Dockerfile
+  - echo "RUN apt update && apt -yq install meson ninja-build libgtest-dev gcc g++" >>  Dockerfile
+  - echo ADD . /root >> Dockerfile
+  - docker build -t pldm .
+
+script:
+  - docker run pldm /bin/bash -c "cd /root && meson -Dlibpldm-only=enabled -Doem-ibm=enabled build && ninja -C build/ test"
+

--- a/libpldm/tests/libpldm_fru_test.cpp
+++ b/libpldm/tests/libpldm_fru_test.cpp
@@ -302,7 +302,7 @@ TEST(GetFruRecordTable, testGoodDecodeRequest)
     auto request =
         reinterpret_cast<pldm_get_fru_record_table_req*>(requestPtr->payload);
 
-    request->data_transfer_handle = htole32(data_transfer_handle);
+    request->data_transfer_handle = data_transfer_handle;
     request->transfer_operation_flag = transfer_operation_flag;
 
     uint32_t ret_data_transfer_handle = 0;
@@ -363,8 +363,7 @@ TEST(GetFruRecordTable, testGoodEncodeResponse)
     ASSERT_EQ(responsePtr->hdr.type, PLDM_FRU);
     ASSERT_EQ(responsePtr->hdr.command, PLDM_GET_FRU_RECORD_TABLE);
     ASSERT_EQ(response->completion_code, PLDM_SUCCESS);
-    ASSERT_EQ(le32toh(response->next_data_transfer_handle),
-              next_data_transfer_handle);
+    ASSERT_EQ(response->next_data_transfer_handle, next_data_transfer_handle);
     ASSERT_EQ(response->transfer_flag, transfer_flag);
 }
 

--- a/libpldm/tests/libpldm_pdr_test.cpp
+++ b/libpldm/tests/libpldm_pdr_test.cpp
@@ -28,7 +28,7 @@ TEST(PDRUpdate, testAdd)
     handle = pldm_pdr_add(repo, data.data(), data.size(), 0);
     EXPECT_EQ(handle, 3);
     handle = pldm_pdr_add(repo, data.data(), data.size(), htole32(0xdeeddeed));
-    EXPECT_EQ(handle, htole32(0xdeeddeed));
+    EXPECT_EQ(handle, 0xdeeddeed);
     EXPECT_EQ(pldm_pdr_get_record_count(repo), 4);
     EXPECT_EQ(pldm_pdr_get_repo_size(repo), data.size() * 4);
 


### PR DESCRIPTION
This builds libpldm and runs the unit tests for amd64, ppc64le and
s390x. The s390x support is important as it provides coverage for big
endian.

Travis at this time only supports Ubuntu 18.04, which contains versions
of meson and ninja that are too old. We instead build in an Ubuntu Eoan
container. When Travis supports 20.04 the container should be dropped.

Change-Id: Ifcb6182817dcaf1ea700a419df99bac3044dedc8
Signed-off-by: Joel Stanley <joel@jms.id.au>